### PR TITLE
Multipart Message Support

### DIFF
--- a/src/erlzmq.erl
+++ b/src/erlzmq.erl
@@ -190,8 +190,8 @@ recv({I, Socket}, Flags)
         Ref when is_reference(Ref) ->
             Timeout = proplists:get_value(timeout, Flags, infinity),
             receive
-                {Ref, Result} ->
-                    {ok, Result}
+                {Ref, Result, Flag} ->
+                    {ok, Result, Flag}
             after Timeout ->
                     {error, {timeout, Ref}}
             end;

--- a/test/erlzmq_test.erl
+++ b/test/erlzmq_test.erl
@@ -15,7 +15,7 @@ hwm_test() ->
 
     ok = hwm_loop(10, S2),
 
-    ?assertMatch({ok, <<"test">>}, erlzmq:recv(S1)),
+    ?assertMatch({ok, <<"test">>, _Flags}, erlzmq:recv(S1)),
     ?assertMatch(ok, erlzmq:send(S2, <<"test">>)),
     ok = erlzmq:close(S1),
     ok = erlzmq:close(S2),
@@ -129,9 +129,17 @@ create_bound_pair(Ctx, Type1, Type2, Mode, Transport) ->
     {S1, S2}.
 
 ping_pong({S1, S2}, Msg, active) ->
+    ok = erlzmq:send(S1, Msg, [sndmore]),
     ok = erlzmq:send(S1, Msg),
     receive
-        {zmq, S2, Msg} ->
+        {zmq, S2, Msg, [rcvmore]} ->
+            ok
+    after
+        1000 ->
+            ?assertMatch({ok, Msg}, timeout)
+    end,
+    receive
+        {zmq, S2, Msg, []} ->
             ok
     after
         1000 ->
@@ -139,7 +147,7 @@ ping_pong({S1, S2}, Msg, active) ->
     end,
     ok = erlzmq:send(S2, Msg),
     receive
-        {zmq, S1, Msg} ->
+        {zmq, S1, Msg, []} ->
             ok
     after
         1000 ->
@@ -147,7 +155,7 @@ ping_pong({S1, S2}, Msg, active) ->
     end,
     ok = erlzmq:send(S1, Msg),
     receive
-        {zmq, S2, Msg} ->
+        {zmq, S2, Msg, []} ->
             ok
     after
         1000 ->
@@ -155,18 +163,23 @@ ping_pong({S1, S2}, Msg, active) ->
     end,
     ok = erlzmq:send(S2, Msg),
     receive
-        {zmq, S1, Msg} ->
+        {zmq, S1, Msg, []} ->
             ok
     after
         1000 ->
             ?assertMatch({ok, Msg}, timeout)
     end,
     ok;
+    
 ping_pong({S1, S2}, Msg, passive) ->
     ok = erlzmq:send(S1, Msg),
-    ?assertMatch({ok, Msg}, erlzmq:recv(S2)),
+    ?assertMatch({ok, Msg, []}, erlzmq:recv(S2)),
     ok = erlzmq:send(S2, Msg),
-    ?assertMatch({ok, Msg}, erlzmq:recv(S1)),
+    ?assertMatch({ok, Msg, []}, erlzmq:recv(S1)),
+    ok = erlzmq:send(S1, Msg, [sndmore]),
+    ok = erlzmq:send(S1, Msg),
+    ?assertMatch({ok, Msg, [rcvmore]}, erlzmq:recv(S2)),
+    ?assertMatch({ok, Msg, []}, erlzmq:recv(S2)),
     ok.
 
 basic_tests(Transport, Type1, Type2, Mode) ->


### PR DESCRIPTION
Right now, as far as I can tell there isn't any way of detecing multipart messages in active mode - this is problematic for using XREP sockets in particular. If there is a way of doing this at the moment, please let me know (I absolutely could have missed it). 

Use case is a simple queue: req -> [xrep -> xreq] -> rep

======= The rest of this message is the original proposal, which is no longer correct! =======
Assuming I haven't missed something, I've attached a patch which is really my sketch of an idea on how to process them. The patch does a RCVMORE based do while loop, and puts all parts into a list. 

Right now, this means an API change, as even individual messages are returned in a list, but I would guess it's probably better to be consistent on this part. I would say that it's likely to want a version of send that accepts a list of binaries - happy to add that as well if this seems like a good way to go (would need doc updates as well, so I don't expect this patch to be merged, more a starting point for discussion). 
