### PR TITLE
rebar clear fix

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -14,7 +14,11 @@ endif
 all: $(DEPS)/zeromq2/src/.libs/libzmq.a
 
 clean:
-	@cd $(DEPS)/zeromq2; make clean
+	if test -e $(DEPS)/zeromq2/Makefile; then \
+		cd $(DEPS)/zeromq2; make clean; \
+	else \
+		true; \
+	fi
 
 distclean:
 	@rm -rf $(DEPS)


### PR DESCRIPTION
When pulling erlzmq2 and running rebar clean an error occurs, this commit fixes it
