### PR TITLE
Update Makefile to use zeromq2-x repo

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -25,7 +25,7 @@ distclean:
 
 $(DEPS)/zeromq2:
 	@mkdir $(DEPS)
-	@git clone git://github.com/zeromq/zeromq2-1.git $(DEPS)/zeromq2
+	@git clone git://github.com/zeromq/zeromq2-x.git $(DEPS)/zeromq2
 	@echo $(ZEROMQ_VERSION)
 	@cd $(DEPS)/zeromq2 && git checkout $(ZEROMQ_VERSION)
 


### PR DESCRIPTION
Fixes build since the zeromq2-1 repo has been renamed [1]

[1] http://lists.zeromq.org/pipermail/zeromq-dev/2012-April/016747.html
