### PR TITLE
modify rebar.config for newer rebar versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,12 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
-{port_envs,
+{port_env,
  [{"DRV_LDFLAGS","deps/zeromq2/src/.libs/libzmq.a -shared $ERL_LDFLAGS -lstdc++ -luuid"},
   {"darwin", "DRV_LDFLAGS", "deps/zeromq2/src/.libs/libzmq.a -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
   {"netbsd", "DRV_LDFLAGS", "deps/zeromq2/src/.libs/libzmq.a -shared $ERL_LDFLAGS -lstdc++"},
   {"DRV_CFLAGS","-Ic_src -Ideps/zeromq2/include -g -Wall -fPIC $ERL_CFLAGS"}]}.
+
+{port_specs, [{"priv/erlzmq_drv.so", ["c_src/*.c"]}]}.
 
 {pre_hooks,[{compile,"make -C c_src"},
             {clean, "make -C c_src clean"}]}.


### PR DESCRIPTION
When using newest rebar to compile erlzmq2 (rebar team recommends compiling newest rebar and putting in OS PATH), the port .so did not get compiled. This patch should fix it.

@nivertech 
