### PR TITLE
Update c_src/erlzmq_nif.c

### DIFF
--- a/c_src/erlzmq_nif.c
+++ b/c_src/erlzmq_nif.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
+#include <sys/types.h>
 
 #define ERLZMQ_MAX_CONCURRENT_REQUESTS 16384
 


### PR DESCRIPTION
Added `#include <sys/types.h>` for the definition of int64_t
on FreeBSD 9.1.

I think this works also on most of Linux and other C compilers.
