### PR TITLE
Small passive receive fix

### DIFF
--- a/src/erlzmq.erl
+++ b/src/erlzmq.erl
@@ -241,6 +241,8 @@ recv({I, Socket}, Flags)
     case erlzmq_nif:recv(Socket, sendrecv_flags(Flags)) of
         Ref when is_reference(Ref) ->
             receive
+                {Ref, {error, _} = Error} ->
+                    Error;
                 {Ref, Result} ->
                     {ok, Result}
             after case erlzmq_nif:getsockopt(Socket,?'ZMQ_RCVTIMEO') of


### PR DESCRIPTION
Always provide a normal error result for very improbable receive errors that occur within the nif context thread.
