### PR TITLE
Remove chained targets in c_src/Makefile to avoid rebuild failures

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -23,13 +23,9 @@ clean:
 distclean:
 	@rm -rf $(DEPS)
 
-$(DEPS):
+$(DEPS)/zeromq3:
 	@mkdir -p $(DEPS)
-
-$(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz: $(DEPS)
 	@curl http://download.zeromq.org/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
-
-$(DEPS)/zeromq3: $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
 	@cd $(DEPS) && tar xzvfp zeromq-$(ZEROMQ_VERSION).tar.gz && mv zeromq-$(ZEROMQ_VERSION) zeromq3
 
 $(DEPS)/zeromq3/src/.libs/libzmq.a: $(DEPS)/zeromq3


### PR DESCRIPTION
There was a bug in the `c_src/Makefile` that caused the decompression and
renaming of the directory in the tar file with the C dependencies to happen
every time the project was built. The bug was experienced as a build
failure when recompiling for the third time. The error that was shown was:

```
mv: cannot move ‘zeromq-3.2.2’ to ‘zeromq3/zeromq-3.2.2’: Directory not empty
```

This was happening because the untarred directory's (`zeromq3`) date in the
filesystem was older than the one from the tar file (`zeromq-3.2.2.tar.gz`).
This was discovered by debugging the make process and seeing this message:

```
Prerequisite `../deps/zeromq-3.2.2.tar.gz' is newer than target `../deps/zeromq3'.
Must remake target `../deps/zeromq3'.
```

The problem was fixed by avoiding chained targets in the `Makefile`.
