### PR TITLE
Do not crash for EINTR in zmq_poll

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -8,7 +8,7 @@ ZMQ_FLAGS=
 endif
 
 ifndef ZEROMQ_VERSION
-ZEROMQ_VERSION=4.0.3
+ZEROMQ_VERSION=4.0.4
 endif
 
 all: $(DEPS)/zeromq4/src/.libs/libzmq.a

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,13 +2,13 @@ LINUX=$(shell uname | grep Linux | wc -l | xargs echo)
 DEPS=../deps
 
 ifeq ($(LINUX),1)
-ZMQ_FLAGS=--with-pic
+ZMQ_FLAGS=--with-pic --with-pgm
 else
 ZMQ_FLAGS=
 endif
 
 ifndef ZEROMQ_VERSION
-ZEROMQ_VERSION=3.2.2
+ZEROMQ_VERSION=3.2.4
 endif
 
 all: $(DEPS)/zeromq3/src/.libs/libzmq.a

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -4,7 +4,7 @@ DEPS=../deps
 ifeq ($(LINUX),1)
 ZMQ_FLAGS=--with-pic --with-pgm
 else
-ZMQ_FLAGS=
+ZMQ_FLAGS=--with-libsodium=/opt/local
 endif
 
 ifndef ZEROMQ_VERSION

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -8,7 +8,7 @@ ZMQ_FLAGS=
 endif
 
 ifndef ZEROMQ_VERSION
-ZEROMQ_VERSION=4.0.1
+ZEROMQ_VERSION=4.0.3
 endif
 
 all: $(DEPS)/zeromq4/src/.libs/libzmq.a

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -8,14 +8,14 @@ ZMQ_FLAGS=
 endif
 
 ifndef ZEROMQ_VERSION
-ZEROMQ_VERSION=3.2.4
+ZEROMQ_VERSION=4.0.1
 endif
 
-all: $(DEPS)/zeromq3/src/.libs/libzmq.a
+all: $(DEPS)/zeromq4/src/.libs/libzmq.a
 
 clean:
-	if test -e $(DEPS)/zeromq3/Makefile; then \
-		cd $(DEPS)/zeromq3; make clean; \
+	if test -e $(DEPS)/zeromq4/Makefile; then \
+		cd $(DEPS)/zeromq4; make clean; \
 	else \
 		true; \
 	fi
@@ -23,10 +23,10 @@ clean:
 distclean:
 	@rm -rf $(DEPS)
 
-$(DEPS)/zeromq3:
+$(DEPS)/zeromq4:
 	@mkdir -p $(DEPS)
 	@curl http://download.zeromq.org/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
-	@cd $(DEPS) && tar xzvfp zeromq-$(ZEROMQ_VERSION).tar.gz && mv zeromq-$(ZEROMQ_VERSION) zeromq3
+	@cd $(DEPS) && tar xzvfp zeromq-$(ZEROMQ_VERSION).tar.gz && mv zeromq-$(ZEROMQ_VERSION) zeromq4
 
-$(DEPS)/zeromq3/src/.libs/libzmq.a: $(DEPS)/zeromq3
-	@cd $(DEPS)/zeromq3 && ./configure $(ZMQ_FLAGS) && make
+$(DEPS)/zeromq4/src/.libs/libzmq.a: $(DEPS)/zeromq4
+	@cd $(DEPS)/zeromq4 && ./configure $(ZMQ_FLAGS) && make

--- a/c_src/erlzmq_nif.c
+++ b/c_src/erlzmq_nif.c
@@ -1136,7 +1136,13 @@ static void * polling_thread(void * handle)
   for (;;) {
     int count = zmq_poll(vector_p(zmq_pollitem_t, &items_zmq),
                          vector_count(&items_zmq), -1);
-    assert(count != -1);
+    if (count == -1) {
+      if (zmq_errno() == EINTR) { continue; }
+
+      fprintf(stderr, "zmq_poll error: %s\n",
+                  strerror(zmq_errno()));
+      assert(0);
+    }
     if (vector_get(zmq_pollitem_t, &items_zmq, 0)->revents & ZMQ_POLLIN) {
       --count;
     }

--- a/include/erlzmq.hrl
+++ b/include/erlzmq.hrl
@@ -46,6 +46,11 @@
 -define('ZMQ_DONTWAIT',    1).
 -define('ZMQ_SNDMORE',     2).
 
+% ZMQ Context options
+-define('ZMQ_IO_THREADS',  1).
+-define('ZMQ_MAX_SOCKETS', 2).
+-define('ZMQ_IPV6', 42).
+
 %% Types
 
 %% Possible types for an erlzmq socket.<br />
@@ -125,3 +130,10 @@
 %% Possible option values for {@link erlzmq:setsockopt/3. setsockopt/3}.
 -type erlzmq_sockopt_value() :: integer() | iolist().
 
+%% Available options for {@link erlzmq:ctx_set/3. ctx_set/3}
+%% and {@link erlzmq:ctx_get/2. ctx_get/2}.<br />
+%% <i>For more information see
+%% <a href="http://api.zeromq.org/master:zmq_ctx_set">zmq_ctx_set</a>
+%% and <a href="http://api.zeromq.org/master:zmq_ctx_get">zmq_ctx_get</a></i>
+
+-type erlzmq_context_opt() :: io_threads | max_sockets | ipv6.

--- a/include/erlzmq.hrl
+++ b/include/erlzmq.hrl
@@ -38,6 +38,10 @@
 -define('ZMQ_SNDTIMEO',          28).
 -define('ZMQ_IPV4ONLY',          31).
 -define('ZMQ_LAST_ENDPOINT',     32).
+-define('ZMQ_CURVE_SERVER',      47).
+-define('ZMQ_CURVE_PUBLICKEY',   48).
+-define('ZMQ_CURVE_SECRETKEY',   49).
+-define('ZMQ_CURVE_SERVERKEY',   50).
 
 %  Message options
 -define('ZMQ_MORE',  1).

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,8 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
 {port_env,
- [{"DRV_LDFLAGS","deps/zeromq4/src/.libs/libzmq.a -shared $ERL_LDFLAGS -lstdc++"},
-  {"darwin", "DRV_LDFLAGS", "deps/zeromq4/src/.libs/libzmq.a -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
+ [{"DRV_LDFLAGS","deps/zeromq4/src/.libs/libzmq.a -L/usr/local/lib -lsodium -shared $ERL_LDFLAGS -lstdc++"},
+  {"darwin", "DRV_LDFLAGS", "deps/zeromq4/src/.libs/libzmq.a -L/opt/local/lib -lsodium -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
   {"DRV_CFLAGS","-Ic_src -Ideps/zeromq4/include -g -Wall -fPIC $ERL_CFLAGS"}]}.
 
 {port_specs, [{"priv/erlzmq_drv.so", ["c_src/*.c"]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,9 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
 {port_env,
- [{"DRV_LDFLAGS","deps/zeromq3/src/.libs/libzmq.a -shared $ERL_LDFLAGS -lstdc++"},
-  {"darwin", "DRV_LDFLAGS", "deps/zeromq3/src/.libs/libzmq.a -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
-  {"DRV_CFLAGS","-Ic_src -Ideps/zeromq3/include -g -Wall -fPIC $ERL_CFLAGS"}]}.
+ [{"DRV_LDFLAGS","deps/zeromq4/src/.libs/libzmq.a -shared $ERL_LDFLAGS -lstdc++"},
+  {"darwin", "DRV_LDFLAGS", "deps/zeromq4/src/.libs/libzmq.a -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
+  {"DRV_CFLAGS","-Ic_src -Ideps/zeromq4/include -g -Wall -fPIC $ERL_CFLAGS"}]}.
 
 {port_specs, [{"priv/erlzmq_drv.so", ["c_src/*.c"]}]}.
 

--- a/src/erlzmq.app.src
+++ b/src/erlzmq.app.src
@@ -1,7 +1,7 @@
 {application, erlzmq,
  [
   {description, "Erlang ZeroMQ Driver"},
-  {vsn, "3.0"},
+  {vsn, "4.0"},
   {modules, [erlzmq, erlzmq_nif]},
   {registered, []},
   {applications, [

--- a/src/erlzmq.erl
+++ b/src/erlzmq.erl
@@ -43,6 +43,8 @@
          close/2,
          term/1,
          term/2,
+         ctx_get/2,
+         ctx_set/3,
          version/0]).
 -export_type([erlzmq_socket/0, erlzmq_context/0]).
 
@@ -380,6 +382,35 @@ term(Context, Timeout) ->
             Result
     end.
 
+%% @doc Get an {@link erlzmq_context_opt(). option} associated with a context.
+%% <br />
+%% <i>For more information see
+%% <a href="http://api.zeromq.org/4-0:zmq_ctx_get">zmq_ctx_get</a>.</i>
+%% @end
+%% (For some reason, the API link to "master:zmq_ctx_get" doesn't work.
+%%  Hardcoding as "4-0".)
+-spec ctx_get(Context :: erlzmq_context(),
+                 Name :: erlzmq_context_opt()) ->
+    {ok, integer()} |
+    erlzmq_error().
+ctx_get(Context, Name) when is_atom(Name) ->
+    erlzmq_nif:ctx_get(Context, c_option_name(Name)).
+
+%% @doc Set an {@link erlzmq_context_opt(). option} associated with an option.
+%% <br />
+%% <i>For more information see
+%% <a href="http://api.zeromq.org/4-0:zmq_ctx_set">zmq_ctx_set</a>.</i>
+%% @end
+%% (For some reason, the API link to "master:zmq_ctx_set" doesn't work.
+%%  Hardcoding as "4-0".)
+-spec ctx_set(Context :: erlzmq_context(),
+                 Name :: erlzmq_context_opt(),
+                 integer()) ->
+    ok |
+    erlzmq_error().
+ctx_set(Context, Name, Value) when is_integer(Value), is_atom(Name) ->
+    erlzmq_nif:ctx_set(Context, c_option_name(Name), Value).
+
 %% @doc Returns the 0MQ library version.
 %% @end
 -spec version() -> {integer(), integer(), integer()}.
@@ -475,3 +506,10 @@ option_name(sndtimeo) ->
     ?'ZMQ_SNDTIMEO';
 option_name(ipv4only) ->
     ?'ZMQ_IPV4ONLY'.
+
+c_option_name(io_threads) ->
+    ?'ZMQ_IO_THREADS';
+c_option_name(max_sockets) ->
+    ?'ZMQ_MAX_SOCKETS';
+c_option_name(ipv6) ->
+    ?'ZMQ_IPV6'.

--- a/src/erlzmq.erl
+++ b/src/erlzmq.erl
@@ -26,6 +26,7 @@
 -include_lib("erlzmq.hrl").
 -export([context/0,
          context/1,
+         context/2,
          socket/2,
          bind/2,
          connect/2,
@@ -48,14 +49,25 @@
          version/0]).
 -export_type([erlzmq_socket/0, erlzmq_context/0]).
 
-%% @equiv context(1)
+%% @equiv context(1, [])
 -spec context() ->
     {ok, erlzmq_context()} |
     erlzmq_error().
 context() ->
-    context(1).
+    context(1, []).
+
+%% @equiv context(Threads, []) or context(1, Opts)
+-spec context(Arg :: pos_integer() | list()) ->
+    {ok, erlzmq_context()} |
+    erlzmq_error().
+context(Threads) when is_integer(Threads) ->
+    context(Threads, []);
+context(Opts) when is_list(Opts) ->
+    context(1, Opts).
 
 %% @doc Create a new erlzmq context with the specified number of io threads.
+%% Optionally, the max_sockets may be specified.  Unlike the zeromq interface,
+%% this must be specified when the context is created.
 %% <br />
 %% If the context can be created an 'ok' tuple containing an
 %% {@type erlzmq_context()} handle to the created context is returned;
@@ -67,11 +79,11 @@ context() ->
 %% <i>For more information see
 %% <a href="http://api.zeromq.org/master:zmq-init">zmq_init</a></i>
 %% @end
--spec context(Threads :: pos_integer()) ->
+-spec context(Threads :: pos_integer(), [{max_sockets, S :: pos_integer}]) ->
     {ok, erlzmq_context()} |
     erlzmq_error().
-context(Threads) when is_integer(Threads) ->
-    erlzmq_nif:context(Threads).
+context(Threads, Opts) when is_integer(Threads), is_list(Opts) ->
+    erlzmq_nif:context(Threads, Opts).
 
 
 %% @doc Create a socket.
@@ -397,6 +409,9 @@ ctx_get(Context, Name) when is_atom(Name) ->
     erlzmq_nif:ctx_get(Context, c_option_name(Name)).
 
 %% @doc Set an {@link erlzmq_context_opt(). option} associated with an option.
+%% <br />
+%% NOTE: Setting max_sockets will have no effect, due to the implementation
+%% of zeromq.  Instead, set max_sockets when creating the context.
 %% <br />
 %% <i>For more information see
 %% <a href="http://api.zeromq.org/4-0:zmq_ctx_set">zmq_ctx_set</a>.</i>

--- a/src/erlzmq.erl
+++ b/src/erlzmq.erl
@@ -46,6 +46,7 @@
          term/2,
          ctx_get/2,
          ctx_set/3,
+         curve_keypair/0,
          version/0]).
 -export_type([erlzmq_socket/0, erlzmq_context/0]).
 
@@ -426,6 +427,20 @@ ctx_get(Context, Name) when is_atom(Name) ->
 ctx_set(Context, Name, Value) when is_integer(Value), is_atom(Name) ->
     erlzmq_nif:ctx_set(Context, c_option_name(Name), Value).
 
+%% @doc Generate a Curve keypair.
+%% <br />
+%% This will return two 40-character binaries, each a Z85-encoded
+%% version of the 32-byte keys from curve.
+%% <br />
+%% <i>For more information see
+%% <a href="http://api.zeromq.org/4-0:zmq_curve_keypair">zmq_curve_keypair</a>.</i>
+%% @end
+-spec curve_keypair() ->
+    {ok, binary(), binary()} |
+    erlzmq_error().
+curve_keypair() ->
+    erlzmq_nif:curve_keypair().
+
 %% @doc Returns the 0MQ library version.
 %% @end
 -spec version() -> {integer(), integer(), integer()}.
@@ -520,7 +535,15 @@ option_name(rcvtimeo) ->
 option_name(sndtimeo) ->
     ?'ZMQ_SNDTIMEO';
 option_name(ipv4only) ->
-    ?'ZMQ_IPV4ONLY'.
+    ?'ZMQ_IPV4ONLY';
+option_name(curve_server) ->
+    ?'ZMQ_CURVE_SERVER';
+option_name(curve_publickey) ->
+    ?'ZMQ_CURVE_PUBLICKEY';
+option_name(curve_secretkey) ->
+    ?'ZMQ_CURVE_SECRETKEY';
+option_name(curve_serverkey) ->
+    ?'ZMQ_CURVE_SERVERKEY'.
 
 c_option_name(io_threads) ->
     ?'ZMQ_IO_THREADS';

--- a/src/erlzmq.erl
+++ b/src/erlzmq.erl
@@ -47,6 +47,7 @@
          ctx_get/2,
          ctx_set/3,
          curve_keypair/0,
+         z85_decode/1,
          version/0]).
 -export_type([erlzmq_socket/0, erlzmq_context/0]).
 
@@ -440,6 +441,19 @@ ctx_set(Context, Name, Value) when is_integer(Value), is_atom(Name) ->
     erlzmq_error().
 curve_keypair() ->
     erlzmq_nif:curve_keypair().
+
+%% @doc Decode a Z85-encode binary
+%% <br />
+%% This will take a binary of size 5*n, and return a binary of size 4*n.
+%% <br />
+%% <i>For more information see
+%% <a href="http://api.zeromq.org/4-1:zmq-z85-decode">zmq_z85_decode</a>.</i>
+%% @end
+-spec z85_decode(binary()) ->
+    {ok, binary(), binary()} |
+    erlzmq_error().
+z85_decode(Z85) ->
+    erlzmq_nif:z85_decode(Z85).
 
 %% @doc Returns the 0MQ library version.
 %% @end

--- a/src/erlzmq_nif.erl
+++ b/src/erlzmq_nif.erl
@@ -14,6 +14,7 @@
          ctx_get/2,
          ctx_set/3,
          curve_keypair/0,
+         z85_decode/1,
          version/0]).
 
 -on_load(init/0).
@@ -74,6 +75,9 @@ ctx_set(_Context, _OptionName, _OptionValue) ->
     erlang:nif_error(not_loaded).
 
 curve_keypair() ->
+    erlang:nif_error(not_loaded).
+
+z85_decode(_Z85) ->
     erlang:nif_error(not_loaded).
 
 version() ->

--- a/src/erlzmq_nif.erl
+++ b/src/erlzmq_nif.erl
@@ -1,7 +1,7 @@
 %% @hidden
 -module(erlzmq_nif).
 
--export([context/1,
+-export([context/2,
          socket/4,
          bind/2,
          connect/2,
@@ -36,7 +36,7 @@ init() ->
             end
     end.
 
-context(_Threads) ->
+context(_Threads, _Opts) ->
     erlang:nif_error(not_loaded).
 
 socket(_Context, _Type, _Active, _ActivePid) ->

--- a/src/erlzmq_nif.erl
+++ b/src/erlzmq_nif.erl
@@ -13,6 +13,7 @@
          term/1,
          ctx_get/2,
          ctx_set/3,
+         curve_keypair/0,
          version/0]).
 
 -on_load(init/0).
@@ -70,6 +71,9 @@ ctx_get(_Context, _OptionName) ->
     erlang:nif_error(not_loaded).
 
 ctx_set(_Context, _OptionName, _OptionValue) ->
+    erlang:nif_error(not_loaded).
+
+curve_keypair() ->
     erlang:nif_error(not_loaded).
 
 version() ->

--- a/src/erlzmq_nif.erl
+++ b/src/erlzmq_nif.erl
@@ -11,6 +11,8 @@
          getsockopt/2,
          close/1,
          term/1,
+         ctx_get/2,
+         ctx_set/3,
          version/0]).
 
 -on_load(init/0).
@@ -62,6 +64,12 @@ close(_Socket) ->
     erlang:nif_error(not_loaded).
 
 term(_Context) ->
+    erlang:nif_error(not_loaded).
+
+ctx_get(_Context, _OptionName) ->
+    erlang:nif_error(not_loaded).
+
+ctx_set(_Context, _OptionName, _OptionValue) ->
     erlang:nif_error(not_loaded).
 
 version() ->

--- a/test/erlzmq_test.erl
+++ b/test/erlzmq_test.erl
@@ -398,9 +398,10 @@ shutdown_blocking_unblocking_test() ->
 
 ctx_opt_test() ->
     ?PRINT_START,
-    {ok, C} = erlzmq:context(),
-    {ok, OrigMS} = erlzmq:ctx_get(C, max_sockets),
-    ?assertMatch(ok, erlzmq:ctx_set(C, max_sockets, OrigMS * 2)),
+    {ok, CDefault} = erlzmq:context(),
+    {ok, OrigMS} = erlzmq:ctx_get(CDefault, max_sockets),
+    ok = erlzmq:term(CDefault),
+    {ok, C} = erlzmq:context([{max_sockets, OrigMS * 2}]),
     {ok, NewMS} = erlzmq:ctx_get(C, max_sockets),
     ?assertMatch(NewMS, OrigMS * 2),
     ok = erlzmq:ctx_set(C, max_sockets, OrigMS),
@@ -416,6 +417,8 @@ ctx_opt_test() ->
     {ok, NewV6} = erlzmq:ctx_get(C, ipv6),
     ?assertMatch(NewV6, 1),
     ok = erlzmq:ctx_set(C, ipv6, 0),
+
+    ok = erlzmq:term(C),
 
     ?PRINT_END.
 

--- a/test/erlzmq_test.erl
+++ b/test/erlzmq_test.erl
@@ -666,3 +666,11 @@ bounce_active(S, C) ->
     expect_content(C, Content, [rcvmore]),
     expect_content(C, Content, []).
 
+z85_decode_test() ->
+    % Sadly, there's no implementation of z85_encode/1, so we
+    % can't do a simple encode/decode = id test.
+    % Amusing test-case from http://rfc.zeromq.org/spec:32
+    ?assertEqual({ok, <<16#86, 16#4F, 16#D2, 16#6F, 16#B5, 16#59, 16#F7, 16#5B>>},
+                 erlzmq:z85_decode(<<"HelloWorld">>)),
+    ?assertEqual(badarg, try erlzmq:z85_decode(atom) catch error:X -> X end),
+    ?assertEqual(badarg, try erlzmq:z85_decode(<<1>>) catch error:X -> X end).

--- a/test/erlzmq_test.erl
+++ b/test/erlzmq_test.erl
@@ -1,5 +1,7 @@
 -module(erlzmq_test).
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("erlzmq.hrl").
+-export_type([erlzmq_socket/0, erlzmq_context/0]).                              
 -export([worker/2]).
 
 % provides some context for failures only viewable within the C code
@@ -392,6 +394,29 @@ shutdown_blocking_unblocking_test() ->
         {Ref, ok} ->
             ok
     end,
+    ?PRINT_END.
+
+ctx_opt_test() ->
+    ?PRINT_START,
+    {ok, C} = erlzmq:context(),
+    {ok, OrigMS} = erlzmq:ctx_get(C, max_sockets),
+    ?assertMatch(ok, erlzmq:ctx_set(C, max_sockets, OrigMS * 2)),
+    {ok, NewMS} = erlzmq:ctx_get(C, max_sockets),
+    ?assertMatch(NewMS, OrigMS * 2),
+    ok = erlzmq:ctx_set(C, max_sockets, OrigMS),
+
+    {ok, OrigIT} = erlzmq:ctx_get(C, io_threads),
+    ?assertMatch(ok, erlzmq:ctx_set(C, io_threads, OrigIT * 2)),
+    {ok, NewIT} = erlzmq:ctx_get(C, io_threads),
+    ?assertMatch(NewIT, OrigIT * 2),
+    ok = erlzmq:ctx_set(C, io_threads, OrigIT),
+
+    {ok, 0} = erlzmq:ctx_get(C, ipv6),
+    ?assertMatch(ok, erlzmq:ctx_set(C, ipv6, 1)),
+    {ok, NewV6} = erlzmq:ctx_get(C, ipv6),
+    ?assertMatch(NewV6, 1),
+    ok = erlzmq:ctx_set(C, ipv6, 0),
+
     ?PRINT_END.
 
 join_procs(0) ->


### PR DESCRIPTION
According to the documentation, zmq_poll can return -1 when signal arrives. This should not lead to crash due to the failed assert.
