### PR TITLE
Update zeromq version to 4.0.5

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,13 +2,13 @@ LINUX=$(shell uname | grep Linux | wc -l | xargs echo)
 DEPS=../deps
 
 ifeq ($(LINUX),1)
-ZMQ_FLAGS=--with-pic
+ZMQ_FLAGS=--with-pic --with-pgm
 else
 ZMQ_FLAGS=
 endif
 
 ifndef ZEROMQ_VERSION
-ZEROMQ_VERSION=3.2.2
+ZEROMQ_VERSION=3.2.4
 endif
 
 all: $(DEPS)/zeromq3/src/.libs/libzmq.a

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -8,7 +8,7 @@ ZMQ_FLAGS=
 endif
 
 ifndef ZEROMQ_VERSION
-ZEROMQ_VERSION=4.0.3
+ZEROMQ_VERSION=4.0.5
 endif
 
 all: $(DEPS)/zeromq4/src/.libs/libzmq.a

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -8,7 +8,7 @@ ZMQ_FLAGS=
 endif
 
 ifndef ZEROMQ_VERSION
-ZEROMQ_VERSION=4.0.1
+ZEROMQ_VERSION=4.0.3
 endif
 
 all: $(DEPS)/zeromq4/src/.libs/libzmq.a

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -8,14 +8,14 @@ ZMQ_FLAGS=
 endif
 
 ifndef ZEROMQ_VERSION
-ZEROMQ_VERSION=3.2.4
+ZEROMQ_VERSION=4.0.1
 endif
 
-all: $(DEPS)/zeromq3/src/.libs/libzmq.a
+all: $(DEPS)/zeromq4/src/.libs/libzmq.a
 
 clean:
-	if test -e $(DEPS)/zeromq3/Makefile; then \
-		cd $(DEPS)/zeromq3; make clean; \
+	if test -e $(DEPS)/zeromq4/Makefile; then \
+		cd $(DEPS)/zeromq4; make clean; \
 	else \
 		true; \
 	fi
@@ -23,10 +23,10 @@ clean:
 distclean:
 	@rm -rf $(DEPS)
 
-$(DEPS)/zeromq3:
+$(DEPS)/zeromq4:
 	@mkdir -p $(DEPS)
 	@curl http://download.zeromq.org/zeromq-$(ZEROMQ_VERSION).tar.gz -o $(DEPS)/zeromq-$(ZEROMQ_VERSION).tar.gz
-	@cd $(DEPS) && tar xzvfp zeromq-$(ZEROMQ_VERSION).tar.gz && mv zeromq-$(ZEROMQ_VERSION) zeromq3
+	@cd $(DEPS) && tar xzvfp zeromq-$(ZEROMQ_VERSION).tar.gz && mv zeromq-$(ZEROMQ_VERSION) zeromq4
 
-$(DEPS)/zeromq3/src/.libs/libzmq.a: $(DEPS)/zeromq3
-	@cd $(DEPS)/zeromq3 && ./configure $(ZMQ_FLAGS) && make
+$(DEPS)/zeromq4/src/.libs/libzmq.a: $(DEPS)/zeromq4
+	@cd $(DEPS)/zeromq4 && ./configure $(ZMQ_FLAGS) && make

--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,9 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
 {port_env,
- [{"DRV_LDFLAGS","deps/zeromq3/src/.libs/libzmq.a -shared $ERL_LDFLAGS -lstdc++"},
-  {"darwin", "DRV_LDFLAGS", "deps/zeromq3/src/.libs/libzmq.a -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
-  {"DRV_CFLAGS","-Ic_src -Ideps/zeromq3/include -g -Wall -fPIC $ERL_CFLAGS"}]}.
+ [{"DRV_LDFLAGS","deps/zeromq4/src/.libs/libzmq.a -shared $ERL_LDFLAGS -lstdc++"},
+  {"darwin", "DRV_LDFLAGS", "deps/zeromq4/src/.libs/libzmq.a -bundle -flat_namespace -undefined suppress $ERL_LDFLAGS"},
+  {"DRV_CFLAGS","-Ic_src -Ideps/zeromq4/include -g -Wall -fPIC $ERL_CFLAGS"}]}.
 
 {port_specs, [{"priv/erlzmq_drv.so", ["c_src/*.c"]}]}.
 

--- a/src/erlzmq.app.src
+++ b/src/erlzmq.app.src
@@ -1,7 +1,7 @@
 {application, erlzmq,
  [
   {description, "Erlang ZeroMQ Driver"},
-  {vsn, "3.0"},
+  {vsn, "4.0"},
   {modules, [erlzmq, erlzmq_nif]},
   {registered, []},
   {applications, [


### PR DESCRIPTION
This work was done by others (@mkrentovskiy and @stephen807), but we (Chef Software) have built on top of it and it would be awesome to see it merged upstream.

This seems pretty straightforward and it passes tests under linux. 

I'd like to get more of the work Chef has done merged in if possible. If this is accepted I'll submitting other work based on this soon. I left this un-squashed so that #67 (which builds on this and other work) can be rebased on top, but if you would prefer I can squash this down to fewer commits. 