### PR TITLE
Fix enif_open_resource_type assertion failure

### DIFF
--- a/c_src/erlzmq_nif.c
+++ b/c_src/erlzmq_nif.c
@@ -1504,13 +1504,13 @@ static ERL_NIF_TERM return_zmq_errno(ErlNifEnv* env, int const value)
 static int on_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
 {
   erlzmq_nif_resource_context =
-    enif_open_resource_type(env, "erlzmq_nif",
+    enif_open_resource_type(env, NULL,
                             "erlzmq_nif_resource_context",
                             NULL,
                             ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER,
                             0);
   erlzmq_nif_resource_socket =
-    enif_open_resource_type(env, "erlzmq_nif",
+    enif_open_resource_type(env, NULL,
                             "erlzmq_nif_resource_socket",
                             NULL,
                             ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER,


### PR DESCRIPTION
According to erlang documentation the argument module_str of
enif_open_resource_type "is not (yet) used and must be NULL." This NULL
value is unfortunately asserted on a debug enabled erlang VM. This
change enables erlzmq2 to be run on such a VM too.
